### PR TITLE
Fix sensitive names list

### DIFF
--- a/src/username_validator/username_validator.py
+++ b/src/username_validator/username_validator.py
@@ -144,7 +144,7 @@ OTHER_SENSITIVE_NAMES = [
     'pricing',
     'privacy',
     'profile',
-    'register'
+    'register',
     'secure',
     'settings',
     'signin',
@@ -155,7 +155,7 @@ OTHER_SENSITIVE_NAMES = [
     'terms',
     'tos',
     'user',
-    'users'
+    'users',
     'weblog',
     'work',
 ]


### PR DESCRIPTION
This PR add commas after some names in the list of sensitive names in order to properly delimit them from the names after them.